### PR TITLE
Alternative and run in scratch container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,27 @@
-FROM golang:1.15.7-buster
+FROM golang:1.15.7-buster as builder
 
-RUN go get -u github.com/beego/bee
+ENV APP_USER app
+ARG GROUP_ID=10001
+ARG USER_ID=10001
 
 ENV GO111MODULE=on
 ENV GOFLAGS=-mod=vendor
+ENV CGO_ENABLED=0
+
+RUN go get -u github.com/beego/bee
+RUN groupadd --gid $GROUP_ID app && useradd -m -l --uid $USER_ID --gid $GROUP_ID $APP_USER
+
+FROM scratch
+
 ENV APP_USER app
 ENV APP_HOME /go/src/mathapp
 
-ARG GROUP_ID
-ARG USER_ID
-
-RUN groupadd --gid $GROUP_ID app && useradd -m -l --uid $USER_ID --gid $GROUP_ID $APP_USER
-RUN mkdir -p $APP_HOME && chown -R $APP_USER:$APP_USER $APP_HOME
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder --chown=$APP_USER /home/$APP_USER /home/$APP_USER
+COPY --from=builder /go/bin/bee /go/bin/bee
 
 USER $APP_USER
 WORKDIR $APP_HOME
 EXPOSE 8010
-CMD ["bee", "run"]
+CMD ["/go/bin/bee", "run"]


### PR DESCRIPTION
Happened to see this project, and thought I might make a small
change.  Rather than making runtime changes in the runtime container,
one could use a scratch container, which has a static built binary,
and non-privileged runtime changes.

This patch doesn't fully work due to bee making an os/exec call to
the `go` executable[1].  However, that is an upstream issue IMO.

[1]: https://github.com/beego/bee/blob/develop/cmd/commands/version/version.go#L176